### PR TITLE
Fix function pointer arguments

### DIFF
--- a/sslkeylog.c
+++ b/sslkeylog.c
@@ -25,6 +25,7 @@
 
 typedef struct ssl_st SSL;
 typedef struct ssl_ctx_st SSL_CTX;
+typedef void (*SSL_CTX_keylog_cb_func)(const SSL *ssl, const char *line);
 
 static __thread int keylog_file_fd = -1;
 static __thread int thread_id = -1;
@@ -104,8 +105,8 @@ static void keylog_callback(const SSL *ssl, const char *line)
 
 SSL *SSL_new(SSL_CTX *ctx)
 {
-    static SSL *(*func)();
-    static void (*set_keylog_cb)();
+    static SSL *(*func)(SSL_CTX *ctx);
+    static void (*set_keylog_cb)(SSL_CTX *ctx, SSL_CTX_keylog_cb_func cb);
     if (!func)
     {
         // fprintf(stderr, "[SSLKEYLOG] INIT\n");


### PR DESCRIPTION
Without this I get the following errors when compiling:
```
$ make
/usr/bin/gcc sslkeylog.c  -shared -o libsslkeylog.so -fPIC -ldl 
sslkeylog.c: In function ‘SSL_new’:
sslkeylog.c:119:9: error: too many arguments to function ‘set_keylog_cb’; expected 0, have 2
  119 |         set_keylog_cb(ctx, keylog_callback);
      |         ^~~~~~~~~~~~~ ~~~
sslkeylog.c:121:12: error: too many arguments to function ‘func’; expected 0, have 1
  121 |     return func(ctx);
      |            ^~~~ ~~~
make: *** [Makefile:2: libsslkeylog.so] Error 1
```